### PR TITLE
Catching error when response is null

### DIFF
--- a/force-regenerate-thumbnails.php
+++ b/force-regenerate-thumbnails.php
@@ -359,6 +359,14 @@ class ForceRegenerateThumbnails {
 					url: ajaxurl,
 					data: { action: "regeneratethumbnail", id: id },
 					success: function(response) {
+						
+						//Catch unknown error
+						if(response === null) {
+							response = {};
+							response.success = false;
+							response.error = 'Unknown error occured.';
+						}
+
 						if (response.success) {
 							RegenThumbsUpdateStatus(id, true, response);
 						} else {


### PR DESCRIPTION
On my setup there was the case that the response variable was null and the whole process of regenerating thumbnails stopped. This fixed it.
