### PR TITLE
Removal of image-type verification to work on PDF with WordPress 4.7

### DIFF
--- a/force-regenerate-thumbnails.php
+++ b/force-regenerate-thumbnails.php
@@ -127,9 +127,6 @@ class ForceRegenerateThumbnails {
 	 */
 	function add_media_row_action($actions, $post) {
 
-		if ('image/' != substr($post->post_mime_type, 0, 6) || !current_user_can($this->capability))
-			return $actions;
-
 		$url = wp_nonce_url( admin_url( 'tools.php?page=force-regenerate-thumbnails&goback=1&ids=' . $post->ID ), 'force-regenerate-thumbnails' );
 		$actions['regenerate_thumbnails'] = '<a href="' . esc_url( $url ) . '" title="' . esc_attr( __( "Regenerate the thumbnails for this single image", 'force-regenerate-thumbnails' ) ) . '">' . __( 'Force Regenerate Thumbnails', 'force-regenerate-thumbnails' ) . '</a>';
 
@@ -451,10 +448,6 @@ class ForceRegenerateThumbnails {
 			if (is_null($image)) {
 				throw new Exception(sprintf(__('Failed: %d is an invalid image ID.', 'force-regenerate-thumbnails'), $id));
 			}
-
-			if ('attachment' != $image->post_type || 'image/' != substr($image->post_mime_type, 0, 6)) {
-				throw new Exception(sprintf(__('Failed: %d is an invalid image ID.', 'force-regenerate-thumbnails'), $id));
-        	}
 
 			if (!current_user_can($this->capability)) {
 				throw new Exception(__('Your user account does not have permission to regenerate images.', 'force-regenerate-thumbnails'));


### PR DESCRIPTION
hi @pedroelsner 

The new version of **WordPress 4.7** (December approach) allows if the server has the _ImageMagick_ library and _Ghostscript_ to be able to create an image of the first page of a PDF file.

[https://make.wordpress.org/core/2016/11/15/enhanced-pdf-support-4-7/](https://make.wordpress.org/core/2016/11/15/enhanced-pdf-support-4-7/)

In testing the beta version, I realized that the plugin does not take into processed the PDF.

I just made a fork that removes the limitation on PDF files.
Can validate this method is to publish your update
