### PR TITLE
Adds pdf files to work with WordPress 4.7

### DIFF
--- a/force-regenerate-thumbnails.php
+++ b/force-regenerate-thumbnails.php
@@ -247,7 +247,7 @@ class ForceRegenerateThumbnails {
 				// of the API functions will return the full post objects which will
 				// suck up lots of memory. This is best, just not as future proof.
 				if (!$images) {
-					if (extension_loaded('imagick') && version_compare( $wp_version, '4.7', '>')) {
+					if (extension_loaded('imagick') && version_compare( $wp_version, '4.7', '>=')) {
 						if (!$images = $wpdb->get_results("SELECT ID FROM $wpdb->posts WHERE post_type = 'attachment' AND post_mime_type LIKE 'image/%' OR post_mime_type LIKE 'application/pdf' ORDER BY ID DESC")) {
 							echo '	<p>' . sprintf(__("Unable to find any images or files pdf. Are you sure <a href='%s'>some exist</a>?", 'force-regenerate-thumbnails'), admin_url('upload.php')) . "</p></div>";
 							return;

--- a/force-regenerate-thumbnails.php
+++ b/force-regenerate-thumbnails.php
@@ -449,15 +449,15 @@ class ForceRegenerateThumbnails {
 			$image = get_post($id);
 
 			if (is_null($image)) {
-				throw new Exception(sprintf(__('Failed: %d is an invalid image ID.', 'force-regenerate-thumbnails'), $id));
+				throw new Exception(sprintf(__('Failed: %d is an invalid media ID.', 'force-regenerate-thumbnails'), $id));
 			}
 
-				throw new Exception(sprintf(__('Failed: %d is an invalid image ID.', 'force-regenerate-thumbnails'), $id));
 			if ('attachment' != $image->post_type || ('image/' != substr($image->post_mime_type, 0, 6) && 'application/pdf' != $image->post_mime_type)) {
+				throw new Exception(sprintf(__('Failed: %d is an invalid media ID.', 'force-regenerate-thumbnails'), $id));
         	}
 
 			if (!current_user_can($this->capability)) {
-				throw new Exception(__('Your user account does not have permission to regenerate images.', 'force-regenerate-thumbnails'));
+				throw new Exception(__('Your user account does not have permission to regenerate media.', 'force-regenerate-thumbnails'));
         	}
             
             

--- a/force-regenerate-thumbnails.php
+++ b/force-regenerate-thumbnails.php
@@ -127,7 +127,7 @@ class ForceRegenerateThumbnails {
 	 */
 	function add_media_row_action($actions, $post) {
 
-		if ('image/' != substr($post->post_mime_type, 0, 6) || !current_user_can($this->capability))
+		if (('application/pdf' != $post->post_mime_type && 'image/' != substr($post->post_mime_type, 0, 6)) || !current_user_can($this->capability))
 			return $actions;
 
 		$url = wp_nonce_url( admin_url( 'tools.php?page=force-regenerate-thumbnails&goback=1&ids=' . $post->ID ), 'force-regenerate-thumbnails' );
@@ -242,7 +242,7 @@ class ForceRegenerateThumbnails {
 				// Directly querying the database is normally frowned upon, but all
 				// of the API functions will return the full post objects which will
 				// suck up lots of memory. This is best, just not as future proof.
-				if (!$images = $wpdb->get_results("SELECT ID FROM $wpdb->posts WHERE post_type = 'attachment' AND post_mime_type LIKE 'image/%' ORDER BY ID DESC")) {
+				if (!$images = $wpdb->get_results("SELECT ID FROM $wpdb->posts WHERE post_type = 'attachment' AND post_mime_type LIKE 'image/%' OR post_mime_type LIKE 'application/pdf' ORDER BY ID DESC")) {
 					echo '	<p>' . sprintf(__("Unable to find any images. Are you sure <a href='%s'>some exist</a>?", 'force-regenerate-thumbnails'), admin_url('upload.php?post_mime_type=image')) . "</p></div>";
 					return;
 				}
@@ -452,8 +452,8 @@ class ForceRegenerateThumbnails {
 				throw new Exception(sprintf(__('Failed: %d is an invalid image ID.', 'force-regenerate-thumbnails'), $id));
 			}
 
-			if ('attachment' != $image->post_type || 'image/' != substr($image->post_mime_type, 0, 6)) {
 				throw new Exception(sprintf(__('Failed: %d is an invalid image ID.', 'force-regenerate-thumbnails'), $id));
+			if ('attachment' != $image->post_type || ('image/' != substr($image->post_mime_type, 0, 6) && 'application/pdf' != $image->post_mime_type)) {
         	}
 
 			if (!current_user_can($this->capability)) {

--- a/force-regenerate-thumbnails.php
+++ b/force-regenerate-thumbnails.php
@@ -246,7 +246,7 @@ class ForceRegenerateThumbnails {
 				// Directly querying the database is normally frowned upon, but all
 				// of the API functions will return the full post objects which will
 				// suck up lots of memory. This is best, just not as future proof.
-				if (!$images) {
+				if (!isset($images)) {
 					if (extension_loaded('imagick') && version_compare( $wp_version, '4.7', '>=')) {
 						if (!$images = $wpdb->get_results("SELECT ID FROM $wpdb->posts WHERE post_type = 'attachment' AND post_mime_type LIKE 'image/%' OR post_mime_type LIKE 'application/pdf' ORDER BY ID DESC")) {
 							echo '	<p>' . sprintf(__("Unable to find any images or files pdf. Are you sure <a href='%s'>some exist</a>?", 'force-regenerate-thumbnails'), admin_url('upload.php')) . "</p></div>";


### PR DESCRIPTION
hi @pedroelsner

The new version of WordPress 4.7 (December approach) allows if the server has the ImageMagick library and Ghostscript to be able to create an image of the first page of a PDF file.

https://make.wordpress.org/core/2016/11/15/enhanced-pdf-support-4-7/

In testing the beta version, I realized that the plugin does not take into processed the PDF.

I just made a new fork, taking into account:
* Adding permissions processed PDF files
* Changes in error messages that take into account the file type or whether the imagick extension is loaded
* Add PDF files to the loop to regenerate all media
* Check if the 'imagick' extension is loaded
* Check if WordPress is at least equal to 4.7